### PR TITLE
Parsing args given as argument

### DIFF
--- a/bioconvert/scripts/converter.py
+++ b/bioconvert/scripts/converter.py
@@ -56,7 +56,7 @@ class ConvAction(argparse.Action):
 def main(args=None):
 
     if args is None:
-        args = sys.argv[:]
+        args = sys.argv[1:]
 
     from easydev.console import purple, underline
     if "-v" in args or "--verbosity" in args:

--- a/bioconvert/scripts/converter.py
+++ b/bioconvert/scripts/converter.py
@@ -141,7 +141,7 @@ def main(args=None):
                             help="Number of trials for each methods")
 
 
-    args = arg_parser.parse_args()
+    args = arg_parser.parse_args(args)
 
     # Set the logging level
     bioconvert.logger_set_level(args.verbosity)


### PR DESCRIPTION
bugfix: currently it is not passing args to argparse.ArgumentParser, making it to use sys.argv[:] whether we provide or not args as argument