### PR TITLE
Sra2fastq

### DIFF
--- a/bioconvert/core/__init__.py
+++ b/bioconvert/core/__init__.py
@@ -29,6 +29,7 @@ extensions = {
     'phylip': ['phy', 'ph', 'phylip'],          # phylo
     'phyloxml': ['phyloxml', 'xml'],            # phylo
     'sam': ["sam"],                             # alignement
+    'sra': ["sra"],                             # sra format
     'stockholm': ['sto', 'sth', 'stockholm'],   # alignment
     'vcf': ['vcf'],                             # variant
     'twobit': ['2bit'],                         # sequence

--- a/bioconvert/sra2fastq.py
+++ b/bioconvert/sra2fastq.py
@@ -51,8 +51,8 @@ class Sra2Fastq(ConvBase):
         if self.isPairedSRA(infile):
            cmd = "fastq-dump --split-files "+infile
            if self.outfile!=outname:
-                   cmd = "mv {0} {1}".format(inbasename+".1.fastq", outbasename+".1.fastq")
-                   cmd = "mv {0} {1}".format(inbasename+".2.fastq", outbasename+".2.fastq")
+                   cmd = "mv {0} {1}".format(inbasename+"_1.fastq", outbasename+"_1.fastq")
+                   cmd = "mv {0} {1}".format(inbasename+"_2.fastq", outbasename+"_2.fastq")
 
         else:
            cmd = "fastq-dump {}".format(infile)

--- a/bioconvert/sra2fastq.py
+++ b/bioconvert/sra2fastq.py
@@ -50,16 +50,19 @@ class Sra2Fastq(ConvBase):
 
         if self.isPairedSRA(infile):
            cmd = "fastq-dump --split-files "+infile
+           self.execute(cmd)
            if self.outfile!=outname:
                    cmd = "mv {0} {1}".format(inbasename+"_1.fastq", outbasename+"_1.fastq")
                    cmd = "mv {0} {1}".format(inbasename+"_2.fastq", outbasename+"_2.fastq")
+                   self.execute(cmd)
 
         else:
            cmd = "fastq-dump {}".format(infile)
+           self.execute(cmd)
            if self.outfile!=outname :
                 cmd = "mv {0} {1}".format(inbasename+".fastq", self.outfile)
+                self.execute(cmd)
 
-        self.execute(cmd)
 
     def isPairedSRA(self,filename):
         try:

--- a/bioconvert/sra2fastq.py
+++ b/bioconvert/sra2fastq.py
@@ -53,9 +53,9 @@ class Sra2Fastq(ConvBase):
            self.execute(cmd)
            if self.outfile!=outname:
                    cmd = "mv {0} {1}".format(inbasename+"_1.fastq", outbasename+"_1.fastq")
+                   self.execute(cmd)
                    cmd = "mv {0} {1}".format(inbasename+"_2.fastq", outbasename+"_2.fastq")
                    self.execute(cmd)
-
         else:
            cmd = "fastq-dump {}".format(infile)
            self.execute(cmd)

--- a/bioconvert/sra2fastq.py
+++ b/bioconvert/sra2fastq.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+#  This file is part of Bioconvert software
+#
+#  Copyright (c) 2017 - Bioconvert Development Team
+#
+#  Distributed under the terms of the 3-clause BSD license.
+#  The full license is in the LICENSE file, distributed with this software.
+#
+#  website: https://github.com/biokit/bioconvert
+#  documentation: http://bioconvert.readthedocs.io
+#
+##############################################################################
+"""Convert :term:`SRA` format to :term:`Fastq` file"""
+from bioconvert import ConvBase, extensions
+import subprocess
+import os
+
+class Sra2Fastq(ConvBase):
+    """Converts Sra 2 Fastq file
+
+    """
+    input_ext = extensions.sra
+    output_ext = extensions.fastq
+
+    def __init__(self, infile, outfile):
+        """.. rubric:: constructor
+        :param str infile:
+        :param str outfile:
+        library used::
+            sra-toolkit
+        """
+        super().__init__(infile, outfile)
+        self._default_method = "sratoolkit"
+
+    def _method_sratoolkit(self, *args, **kwargs):
+        """
+        Uses Sratoolkit (fastq-dump) to convert a sra file to fastq
+        """
+        outname='{}.{}'.format(os.path.splitext(self.infile)[0],"fastq")
+        inbasename=os.path.splitext(self.infile)[0]
+        outbasename=os.path.splitext(self.outfile)[0]
+        infile = self.infile
+
+        # If the file does not exist locally, we take the basename
+        # it should correspond to a SRA ID
+        if os.path.isfile(infile) is False:
+            infile = os.path.splitext(self.infile)[0]
+            infile = os.path.split(infile)[1]
+
+        if self.isPairedSRA(infile):
+           cmd = "fastq-dump --split-files "+infile
+           if self.outfile!=outname:
+                   cmd = "mv {0} {1}".format(inbasename+".1.fastq", outbasename+".1.fastq")
+                   cmd = "mv {0} {1}".format(inbasename+".2.fastq", outbasename+".2.fastq")
+
+        else:
+           cmd = "fastq-dump {}".format(infile)
+           if self.outfile!=outname :
+                cmd = "mv {0} {1}".format(inbasename+".fastq", self.outfile)
+
+        self.execute(cmd)
+
+    def isPairedSRA(self,filename):
+        try:
+            contents = subprocess.check_output(["fastq-dump","-X","1","-Z","--split-spot", filename]);
+        except subprocess.CalledProcessError:
+            raise Exception("Error running fastq-dump on",filename);
+
+        if(contents.count(b'\n') == 4):
+            return False;
+        elif(contents.count(b'\n') == 8):
+            return True;
+        else:
+            raise Exception("Unexpected output from fast-dump on ", filename);
+        

--- a/requirements_tools.txt
+++ b/requirements_tools.txt
@@ -14,3 +14,4 @@ go=1.9.2
 ucsc-twobittofa
 ucsc-fatotwobit
 ucsc-bigwigtobedgraph
+sra-tools


### PR DESCRIPTION
New converter sra2fastq:

Local/Distant:
- If the given sra file exists locally : it converts it to fastq
- If the given sra file does not exists locally: it takes the input file name without path and extension, considers it as a SRA ID, and downloads it from SRA

Single/Paired end:
- If the sra file is "single end": produces 1 fastq file with the given output name
- If the sra file is "paired-end": produces 2 fastq files  with prefix=output file name and suffix= _1.fastq and _2.fastq

testable with:

bioconvert SRR390728.sra test.fastq