### PR TITLE
Better check of compressed file

### DIFF
--- a/bioconvert/core/base.py
+++ b/bioconvert/core/base.py
@@ -352,7 +352,7 @@ class ConvBase(metaclass=ConvMeta):
             return output
 
     def boxplot_benchmark(self, N=5, rerun=True, include_dummy=False,
-            to_exclude=[], to_include=[]):
+            to_exclude=[], to_include=[], rot_xticks=90, boxplot_args={}):
         """Simple wrapper to call :class:`Benchmark` and plot the results
 
         see :class:`~bioconvert.core.benchmark.Benchmark` for details.
@@ -361,7 +361,9 @@ class ConvBase(metaclass=ConvMeta):
         self._benchmark = Benchmark(self, N=N, to_exclude=to_exclude,
                                     to_include=to_include)
         self._benchmark.include_dummy = include_dummy
-        self._benchmark.plot(rerun=rerun)
+        data = self._benchmark.plot(rerun=rerun, rot_xticks=rot_xticks,
+                                    boxplot_args=boxplot_args)
+        return data
 
     def _get_default_method(self):
         if self._default_method is None:

--- a/bioconvert/core/benchmark.py
+++ b/bioconvert/core/benchmark.py
@@ -114,22 +114,38 @@ class Benchmark():
             results[method] = times
         self.results = results
 
-    def plot(self, rerun=False, ylabel="Time (seconds)"):
-        import pylab
+    def plot(self, rerun=False, ylabel="Time (seconds)", rot_xticks=0, 
+             boxplot_args={}):
         """Plots the benchmark results, running the benchmarks
-        if needed or if *rerun* is True."""
+        if needed or if *rerun* is True.
+
+        :param rot_xlabel: rotation of the xticks function
+        :param boxplot_args: dictionary with any of the pylab.boxplot arguments
+        :return: dataframe with all results
+        """
+        import pylab
         if self.results is None or rerun is True:
             self.run_methods()
-        # an alias
-        data = self.results
+
+        # an alias.
+        data = self.results.copy()
 
         methods = sorted(data, key=lambda x: pylab.mean(data[x]))
-        pylab.boxplot([data[x] for x in methods])
+        pylab.boxplot([data[x] for x in methods], **boxplot_args)
         # pylab.xticks([1+this for this in range(len(methods))], methods)
-        pylab.xticks(*zip(*enumerate(methods, start=1)))
+        if "vert" in boxplot_args and boxplot_args['vert'] is False:
+            pylab.yticks(*zip(*enumerate(methods, start=1)), rotation=rot_xticks)
+            pylab.xlabel(ylabel)
+            #pylab.xlim([0, len(methods)+1])
+        else:
+            pylab.xticks(*zip(*enumerate(methods, start=1)), rotation=rot_xticks)
+            pylab.ylabel(ylabel)
+            pylab.xlim([0, len(methods)+1])
+
         pylab.grid(True)
-        pylab.ylabel(ylabel)
-        pylab.xlim([0, len(methods)+1])
+        pylab.tight_layout()
+
+        return data
 
 
 class BenchmarkMulticonvert(Benchmark):

--- a/bioconvert/core/decorators.py
+++ b/bioconvert/core/decorators.py
@@ -33,6 +33,19 @@ from easydev import TempFile
 _log = colorlog.getLogger(__name__)
 
 
+def is_gz(file_path):
+    """Detect if file is a gziped file based on first two bit of file."""
+    with open(file_path) as f:
+        file_start = f.read(2)
+
+    # according to http://www.zlib.org/rfc-gzip.html#header-trailer
+    # all gzipfile begin by bit 0x1F and 0x8b
+    if file_start == "\x1f\x8b":
+            return True
+
+    return False
+
+
 def in_gz(func):
     """Marks a function as accepting gzipped input."""
     func.in_gz = True
@@ -75,7 +88,7 @@ def compressor(func):
             (inst.outfile, output_compressed) = splitext(inst.outfile)
         # Now inst has the uncompressed output file name
 
-        if infile_name.endswith(".gz"):
+        if is_gz(infile_name):
             # decompress input
             # TODO: https://stackoverflow.com/a/29371584/1878788
             _log.info("Generating uncompressed version of %s " % infile_name)

--- a/bioconvert/fastq2fasta.py
+++ b/bioconvert/fastq2fasta.py
@@ -132,7 +132,6 @@ class Fastq2Fasta(ConvBase):
                 fasta.write(">{}\n{}\n".format(
                     record.comment.decode("utf-8"),
                     record.sequence.decode("utf-8")))
-        print("test")
 
     @requires_nothing
     @compressor

--- a/doc/Snakefile
+++ b/doc/Snakefile
@@ -1,5 +1,5 @@
 # This Snakefile read all Fastq files in the current directory
-# and convert them into Fasta; 
+# and convert them into Fasta
 #
 # How to run ? If you have 8 cores:
 #
@@ -7,12 +7,14 @@
 #
 # on a SLURM framework, :
 #
-#     snakemake -s Snakefile --cluster "-j 8 --mem 1000"
+#     snakemake -s Snakefile --cluster "-j 8 --mem 4000"
 
 from pylab import savefig
 
 inext = "fastq"
 outext = "fasta"
+command = "fastq2fasta"
+
 
 import glob
 samples = glob.glob("*%s" % inext)
@@ -24,5 +26,5 @@ rule all:
 rule bioconvert:
     input: "{dataset}.%s" % inext
     output: "{dataset}.%s" % outext
-    shell: "bioconvert {input} {output}"
+    shell: "bioconvert {} {input} {output}".format(command)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -152,10 +152,6 @@ modindex_common_prefix = ["bioconvert."]
 # By default, examples are not built locally. You can set plot_gallery to True
 # to force their creation. Note that it requires singularity or dot to be
 # installed. Fixes https://github.com/biokit/bioconvert/issues/153
-if not on_rtd:
-    plot_gallery = False
-else:
-    plot_gallery = True
 
 plot_gallery = True
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -173,15 +173,6 @@ sphinx_gallery_conf = {
 numpydoc_show_class_members = False
 
 
-modpath = os.path.join("modules")
-genpath = os.path.join("modules", "generated")
-if os.path.exists(modpath) is False:
-    print("---------------hello")
-    os.mkdir(modpath)
-    if os.path.exists(genpath) is False:
-        print("hello25")
-        os.mkdir(genpath)
-
 # solution from nilearn
 def touch_example_backreferences(app, what, name, obj, options, lines):
     # generate empty examples files, so that we don't get
@@ -302,7 +293,6 @@ htmlhelp_basename = 'doc'
 # NOT in original quickstart
 pngmath_use_preview = True
 
-
 # The font size ('10pt', '11pt' or '12pt').
 latex_font_size = '10pt'
 
@@ -315,7 +305,6 @@ latex_documents = [
 
 latex_elements = { 'inputenc': '\\usepackage[utf8]{inputenc}' }
 latex_elements["latex_paper_size"] = "a4"
-
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
 #latex_logo = None

--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -30,8 +30,6 @@ all in small caps ! In this file, copy and paste this example::
         """
 
         """
-        input_ext = ['.fastq']
-        output_ext = '.fasta'
         _default_method = "v1"
 
         def __init__(self, infile, outfile):

--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -49,13 +49,13 @@ all in small caps ! In this file, copy and paste this example::
             another method
 
 You may also use this standalone to create the bioconvert_init standalone. For
-instance to create the bz2 to gz convertm redirect the output of this command in
+instance to create the *sam* to *bam* conversion, redirect the output of the following command in
 the correct file::
 
-    $ bioconvert_init -i bz2 -o gz > bz22gz.py
+    $ bioconvert_init -i sam -o bam > sam2bam.py
 
 Of course, you will need to edit the file to add the conversion itself in the
-appropriate method (e.g. _method_gz).
+appropriate method (e.g. _method_samtools).
 
 
 How to add a new method

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,7 @@ possible and provide facilities to compare different conversion tools or methods
 via `benchmarking <benchmarking>`_. New implementations are provided when considered 
 better than existing ones.
 
-**Currently (March 2018), we have 35 formats, 63 direct conversions (much more are
+**Currently (June 2018), we have 66 formats, 120 direct conversions (much more are
 possible calling bioconvert several times).**
 
 Installation
@@ -76,10 +76,13 @@ Otherwise, please see the instructions on `bioconda <https://bioconda.github.io/
 Usage
 ##########
 
-From the command line::
+From the command line, you can convert a fastq to fasta as follows (compressed
+or not)::
 
     bioconvert fastq2fasta input.fastq output.fasta
-    bioconvert fastq2fasta input.fq output.fasta
+    bioconvert fastq2fasta input.fq    output.fasta
+    bioconvert fastq2fasta input.fq.gz output.fasta.gz
+    bioconvert fastq2fasta input.fq.gz output.fasta.bz2
     bioconvert --help
 
 From Python shell::

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -13,17 +13,41 @@ You can obtain help by using::
 
     bioconvert --help
 
+To convert a format into another you need to provide the name of the conversion.
+For instance, to convert a fastq file into a fasta, you need to use the sub
+command **fastq2fasta**::
+
+    bioconvert fastq2fasta  input.fastq output.fasta
+
+The rationale behind the subcommand choice is manyfold. First, you may have dedicated help
+for a given conversion::
+
+    bioconvert fastq2fasta --help
+
+Second, the extensions of your input and output may be non-standard or different
+from the bioconvert choice. So, using the subcommand you can do::
+
+    bioconvert fastq2fasta  input.fq output.fa
+
+where the extensions can actually be whatever you want.
+
 
 Installation
 -------------
 
-pip method
-~~~~~~~~~~~~~
-For developers, **bioconvert** standalone is installed with the package available on Pypi so you could type::
+pip pr conda methods
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-    pip install bioconvert 
+For users, **bioconvert** standalone is installed with the package **bioconvert** available on Pypi so you could type::
 
-This method installs bioconvert and its Python dependencies (available on Pypi website). Note, however, that **bioconvert** may use (depending on the conversion you want to use) external dependencies not available on Pypi. You will need to install those third-party dependencies yourself. An alternative is to install bioconvert using **conda**. 
+    pip install bioconvert
+
+This method installs bioconvert and its Python dependencies (available on Pypi website). Note, however, that **bioconvert** may use (depending on the conversion you want to use) external dependencies not available on Pypi. You will need to install those third-party dependencies yourself. An alternative is to install bioconvert using **conda** using::
+
+    conda install bioconvert
+
+Note that you will need to set up the **bioconda** channel (see below for
+details).
 
 conda / bioconda method
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hello,

According to the gzip [rfc](http://www.zlib.org/rfc-gzip.html#header-trailer) all gzip file begin by two bits 0x1F and 0x8b.

This pull request replace test based on file extension by a check of two first bit of file.

Plus:
- support any type of extension .gz, .gzip, .compress, .z
- User can't lie :)

Minus:
- computation time increase.
- possible collision (very unlikely or voluntary) 

Evolution:

We can write similar test for many compression format like bzip2 or lzma

Thanks for your work.
